### PR TITLE
Create appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,28 @@
+version: build-{build}-{branch}
+
+environment:
+  GH_RECORD_MODE: "none"
+  matrix:
+    # http://www.appveyor.com/docs/installed-software#python lists available
+    # versions
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python27-x64"
+    #- PYTHON: "C:\\Python37"
+    #- PYTHON: "C:\\Python37-x64"
+
+init:
+  - "echo %PYTHON%"
+
+install:
+  - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - python --version
+  - python -m pip install --upgrade pip setuptools
+  - python -m pip install --upgrade flake8
+
+build: false
+
+test_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics


### PR DESCRIPTION
Fixes #7  AppVeyor makes the most sense because they have tons of Windows instances to use.

Log into the free plan with GitHub credentials at https://github.com/marketplace/appveyor

OS and Python combinations available http://www.appveyor.com/docs/installed-software#python