### PR TITLE
Add Travis CI automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ matrix:
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
       before_install:
         - choco install python
-        - python -m pip install py2exe
+        #- python -m pip install py2exe
     - name: "Python 2 on Windows"
       env: PATH=/c/Python27:/c/Python27/Scripts:$PATH
       before_install:
-        - choco install python2 vcpython27
-        - python -m pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
+        - choco install python2  # vcpython27
+        # - python -m pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
   allow_failures:
     - name: "Python 3 on Windows"
 
@@ -23,4 +23,4 @@ install:
 
 script:
   - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
-  - python build.py
+  # - python build.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,20 @@ matrix:
   include:
     - name: "Python 3 on Windows"
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
-      before_install: choco install python
+      before_install:
+        - choco install python
+        - python -m pip install py2exe
     - name: "Python 2 on Windows"
       env: PATH=/c/Python27:/c/Python27/Scripts:$PATH
-      before_install: choco install python2
+      before_install:
+        - choco install python2
+        - python -m pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
   allow_failures:
     - name: "Python 3 on Windows"
 
 install:
   - python -m pip install --upgrade pip
-  - python -m pip install flake8 py2exe -r requirements.txt
+  - python -m pip install flake8 -r requirements.txt
 
 script:
   - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,22 @@
 os: windows
 language: shell  # 'language: python' is not yet supported on Windows
-env:
-  - PYTHONUNBUFFERED=1
+env: PYTHONUNBUFFERED=1
 
 matrix:
   include:
     - name: "Python 3 on Windows"
-      env: PATH=/c/Python37:$PATH
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
       before_install: choco install python
     - name: "Python 2 on Windows"
-      env: PATH=/c/Python27:$PATH
+      env: PATH=/c/Python27:/c/Python27/Scripts:$PATH
       before_install: choco install python2
   allow_failures:
     - name: "Python 3 on Windows"
 
-
 install:
   - python -m pip install --upgrade pip
-  - python -m pip install flake8 -r requirements.txt
+  - python -m pip install flake8 py2exe -r requirements.txt
 
 script:
-  - python -m flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
   - python build.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ matrix:
     - name: "Python 2 on Windows"
       env: PATH=/c/Python27:/c/Python27/Scripts:$PATH
       before_install:
-        - choco install python2 vcredist2008 --ignore-dependencies vcpython27
+        - choco install python2 vcredist2008
+        - choco install --ignore-dependencies vcpython27
         - python -m pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
   allow_failures:
     - name: "Python 3 on Windows"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ matrix:
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
       before_install:
         - choco install python
-        #- python -m pip install py2exe
+        - python -m pip install py2exe
     - name: "Python 2 on Windows"
       env: PATH=/c/Python27:/c/Python27/Scripts:$PATH
       before_install:
-        - choco install python2  # vcpython27
-        # - python -m pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
+        - choco install python2 vcredist2008 --ignore-dependencies vcpython27
+        - python -m pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
   allow_failures:
     - name: "Python 3 on Windows"
 
@@ -23,4 +23,4 @@ install:
 
 script:
   - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
-  # - python build.py
+  - python build.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - name: "Python 2 on Windows"
       env: PATH=/c/Python27:/c/Python27/Scripts:$PATH
       before_install:
-        - choco install python2
+        - choco install python2 vcpython27
         - python -m pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
   allow_failures:
     - name: "Python 3 on Windows"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+os: windows
+language: shell  # 'language: python' is not yet supported on Windows
+env:
+  - PYTHONUNBUFFERED=1
+
+matrix:
+  include:
+    - name: "Python 3 on Windows"
+      env: PATH=/c/Python37:$PATH
+      before_install: choco install python
+    - name: "Python 2 on Windows"
+      env: PATH=/c/Python27:$PATH
+      before_install: choco install python2
+  allow_failures:
+    - name: "Python 3 on Windows"
+
+
+install:
+  - python -m pip install --upgrade pip
+  - python -m pip install flake8 -r requirements.txt
+
+script:
+  - python -m flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  - python build.py


### PR DESCRIPTION
Related to #19  The owner of the this repo would need to go to https://travis-ci.com/profile, log in with GitHub credentials, ___select the free plan___, and flip the repository switch on to enable free automated testing of all pull requests.  Travis will lint all Python files with [flake8](http://flake8.pycqa.org) and then run __python build.py__.  Python 2 and Python 3 tests run in parallel but the Python 3 tests are run in __allow_failures__ mode until the port to Python 3 is complete.  Travis CI is free to open source project like this one.