### PR TITLE
Travis CI: Build the exe with py2exe and PyInstaller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: shell  # 'language: python' is not yet supported on Windows
 
 env:
   global:
-    - PYTHONUNBUFFERED=1
     - PY27PATH=/c/Python27:/c/Python27/Scripts
     - PY37PATH=/c/Python37:/c/Python37/Scripts
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,15 +11,15 @@ py27-steps: &py27-steps
   env: PATH=$PY27PATH:$PATH
   before_install:
     - choco install python2
-    - python -m pip install --upgrade pip
-    - python -m pip install -r requirements.txt
+    - pip install --upgrade pip
+    - pip install -r requirements.txt
 
 py37-steps: &py37-steps
   env: PATH=$PY37PATH:$PATH
   before_install:
     - choco install python
-    - python -m pip install --upgrade pip
-    - python -m pip install -r requirements.txt
+    - pip install --upgrade pip
+    - pip install -r requirements.txt
 
 py2exe-steps: &py2exe-steps
   script:
@@ -32,7 +32,7 @@ py2exe-steps: &py2exe-steps
 
 pyinstaller-steps: &pyinstaller-steps
   install:
-    - python -m pip install pyinstaller
+    - pip install pyinstaller
   script:
     - pyinstaller --onefile winpwnage.py
     - ls dist
@@ -70,7 +70,7 @@ matrix:
       before_script: pip uninstall -y enum34
 
 install:
-  - python -m pip install flake8
+  - pip install flake8
 
 script:
   - flake8 . --count --select=E9,F401,F63,F72,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,20 +2,17 @@ os: windows
 language: shell  # 'language: python' is not yet supported on Windows
 
 env:
-  global:
-    - PYTHONUNBUFFERED=1
-    - PY27PATH=/c/Python27:/c/Python27/Scripts
-    - PY37PATH=/c/Python37:/c/Python37/Scripts
+  global: PYTHONUNBUFFERED=1
 
 py27-steps: &py27-steps
-  env: PATH=$PY27PATH:$PATH
+  env: PATH=/c/Python27:/c/Python27/Scripts:$PATH
   before_install:
     - choco install python2
     - python -m pip install --upgrade pip
     - pip install -r requirements.txt
 
 py37-steps: &py37-steps
-  env: PATH=$PY37PATH:$PATH
+  env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
   before_install:
     - choco install python
     - python -m pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,5 @@ install:
 script:
   - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
   - python build.py winpwnage.py
+  - ls
+  - ls dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ install:
 
 script:
   - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
-  - python build.py
+  - python build.py winpwnage.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ py37-steps: &py37-steps
     - python -m pip install -r requirements.txt
 
 scan-steps: &scan-steps
-  - python winpwnage.py -scan -uac
-  - python winpwnage.py -scan -persist
-  - python winpwnage.py -scan -elevate
-  - python winpwnage.py -scan -execute
+  install:
+    - python winpwnage.py -scan -uac
+    - python winpwnage.py -scan -persist
+    - python winpwnage.py -scan -elevate
+    - python winpwnage.py -scan -execute
 
 pyinstaller-steps: &pyinstaller
   install:
@@ -79,4 +80,9 @@ install:
 
 script:
   - flake8 . --count --select=E9,F401,F63,F72,F82 --show-source --statistics
-  <<: *scan-steps
+  # <<: *scan-steps
+  - python winpwnage.py -scan -uac
+  - python winpwnage.py -scan -persist
+  - python winpwnage.py -scan -elevate
+  - python winpwnage.py -scan -execute
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,10 @@ matrix:
         - python -m pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
       <<: *py2exe-steps
     - name: "Py3: Build exe with py2exe"
-      <<: *py27-steps
+      <<: *py37-steps
       install:
         - python -m pip install py2exe
-     <<: *py2exe-steps
+      <<: *py2exe-steps
 
     - name: "Py2: Build exe with PyInstaller"
       <<: *py27-steps

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@
 # before_script: Executes run-specific tools and then sets $RUN_WINPWNAGE
 # script: Executes WinPwnage
 
-os: windows      # Windows Server, version 1803
+os: windows      # Windows Server, version 1803 -- Platform: Windows-10-10.0.17134-SP0
 language: shell  # 'language: python' is not yet supported on Travis CI Windows
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ py37-steps: &py37-steps
     - python -m pip install --upgrade pip
     - pip install -r requirements.txt
 
+py2exe-steps: &py2exe-steps
+  before_script:
+    - python build_win64.py winpwnage.py
+    - ls -l dist  # See file size, etc.
+    - RUN_WINPWNAGE=dist/winpwnage.exe
+
 pyinstaller-steps: &pyinstaller-steps
   install:
     - pip install pyinstaller
@@ -52,10 +58,7 @@ matrix:
         - choco install vcredist2008
         - choco install --ignore-dependencies vcpython27
         - pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
-      before_script: &py2exe-steps
-        - python build_win64.py winpwnage.py
-        - ls -l dist  # See file size, etc.
-        - RUN_WINPWNAGE=dist/winpwnage.exe
+      <<: *py2exe-steps
     - name: "Py3: Build exe with py2exe"
       <<: *py37-steps
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ py27-steps: &py27-steps
   env: PATH=$PY27PATH:$PATH
   before_install:
     - choco install python2
-    - pip install --upgrade pip
+    - python -m pip install --upgrade pip
     - pip install -r requirements.txt
 
 py37-steps: &py37-steps
   env: PATH=$PY37PATH:$PATH
   before_install:
     - choco install python
-    - pip install --upgrade pip
+    - python -m pip install --upgrade pip
     - pip install -r requirements.txt
 
 py2exe-steps: &py2exe-steps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,45 @@
 os: windows
 language: shell  # 'language: python' is not yet supported on Windows
 
+env:
+  global:
+    - PYTHONUNBUFFERED=1
+    - PY27PATH=/c/Python27:/c/Python27/Scripts
+    - PY37PATH=/c/Python37:/c/Python37/Scripts
+
 py27-steps: &py27-steps
-  env: PATH=/c/Python27:/c/Python27/Scripts:$PATH
+  env: PATH=PY27PATH:$PATH
   before_install:
     - choco install python2
     - python -m pip install --upgrade pip
     - python -m pip install -r requirements.txt
 
 py37-steps: &py37-steps
-  env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+  env: PATH=PY37PATH:$PATH
   before_install:
     - choco install python
     - python -m pip install --upgrade pip
     - python -m pip install -r requirements.txt
 
-scan-steps: &scan-steps
-  install:
-    - python winpwnage.py -scan -uac
-    - python winpwnage.py -scan -persist
-    - python winpwnage.py -scan -elevate
-    - python winpwnage.py -scan -execute
+py2exe-steps: &py2exe-steps
+  script:
+    - python build_win64.py winpwnage.py
+    - ls dist
+    - dist/winpwnage.exe  -scan -uac
+    - dist/winpwnage.exe  -scan -persist
+    - dist/winpwnage.exe  -scan -elevate
+    - dist/winpwnage.exe  -scan -execute
 
-pyinstaller-steps: &pyinstaller
+pyinstaller-steps: &pyinstaller-steps
   install:
-    - python -m pip install --upgrade pip
-    - python -m pip install pyinstaller -r requirements.txt
-
-env:
-  global:
-    - PYTHONUNBUFFERED=1
-    - PY27PATH=/c/Python27:/c/Python27/Scripts
-    - PY37PATH=/c/Python37:/c/Python37/Scripts
+    - python -m pip install pyinstaller
+  script:
+    - pyinstaller --onefile winpwnage.py
+    - ls dist
+    - dist/winpwnage.exe  -scan -uac
+    - dist/winpwnage.exe  -scan -persist
+    - dist/winpwnage.exe  -scan -elevate
+    - dist/winpwnage.exe  -scan -execute
 
 matrix:
   include:
@@ -41,39 +49,24 @@ matrix:
       <<: *py37-steps
 
     - name: "Py2: Build exe with py2exe"
-      env: PATH=/c/Python27:/c/Python27/Scripts:$PATH
-      before_install:
-        - choco install python2 vcredist2008
+      <<: *py27-steps
+      install:
+        - choco install vcredist2008
         - choco install --ignore-dependencies vcpython27
         - python -m pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
-      install: true
-      script:
-        - python build_win64.py winpwnage.py
-        - ls
-        - ls dist
+      <<: *py2exe-steps
     - name: "Py3: Build exe with py2exe"
-      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
-      before_install:
-        - choco install python
+      <<: *py27-steps
+      install:
         - python -m pip install py2exe
-      install: true
-      script:
-        - python build_win64.py winpwnage.py
-        - ls
-        - ls dist
+     <<: *py2exe-steps
 
     - name: "Py2: Build exe with PyInstaller"
-      env: PATH=$PY27PATH:$PATH
-      before_install:
-        - choco install python2
-        - python -m pip install --upgrade pip
-        - python -m pip install pyinstaller -r requirements.txt
+      <<: *py27-steps
+      <<: *pyinstaller-steps
     - name: "Py3: Build exe with PyInstaller"
-      env: PATH=$PY37PATH:$PATH
-      before_install:
-        - choco install python
-        - python -m pip install --upgrade pip
-        - python -m pip install pyinstaller -r requirements.txt
+      <<: *py37-steps
+      <<: *pyinstaller-steps
 
 install:
   - python -m pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,12 +53,12 @@ matrix:
       install:
         - choco install vcredist2008
         - choco install --ignore-dependencies vcpython27
-        - python -m pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
+        - pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
       <<: *py2exe-steps
     - name: "Py3: Build exe with py2exe"
       <<: *py37-steps
       install:
-        - python -m pip install py2exe
+        - pip install py2exe
       <<: *py2exe-steps
 
     - name: "Py2: Build exe with PyInstaller"
@@ -67,6 +67,7 @@ matrix:
     - name: "Py3: Build exe with PyInstaller"
       <<: *py37-steps
       <<: *pyinstaller-steps
+      before_script: pip uninstall -y enum34
 
 install:
   - python -m pip install flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
-os: windows
-language: shell  # 'language: python' is not yet supported on Windows
+# https://blog.travis-ci.com/2018-10-11-windows-early-release
+# https://docs.travis-ci.com/user/reference/windows
+# https://chocolatey.org/packages/python
+# https://www.pyinstaller.org
+
+# before_install: Installs Python, upgrades pip, pip installs requirements.txt
+# install: Installs run-specific tools like Flake8, py2exe, PyInstaller
+# before_script: Executes run-specific tools and then sets $RUN_WINPWNAGE
+# script: Executes WinPwnage
+
+os: windows      # Windows Server, version 1803
+language: shell  # 'language: python' is not yet supported on Travis CI Windows
 
 env:
   global:
@@ -20,25 +30,14 @@ py37-steps: &py37-steps
     - python -m pip install --upgrade pip
     - pip install -r requirements.txt
 
-py2exe-steps: &py2exe-steps
-  script:
-    - python build_win64.py winpwnage.py
-    - ls dist
-    - dist/winpwnage.exe  -scan -uac
-    - dist/winpwnage.exe  -scan -persist
-    - dist/winpwnage.exe  -scan -elevate
-    - dist/winpwnage.exe  -scan -execute
-
 pyinstaller-steps: &pyinstaller-steps
   install:
     - pip install pyinstaller
-  script:
-    - pyinstaller --console --onefile winpwnage.py
-    - ls dist
-    - dist/winpwnage.exe  -scan -uac
-    - dist/winpwnage.exe  -scan -persist
-    - dist/winpwnage.exe  -scan -elevate
-    - dist/winpwnage.exe  -scan -execute
+  before_script:
+    - pyinstaller --onefile winpwnage.py
+    - sleep 1  # Give PyInstaller a second to finish writing to stdout
+    - ls -l dist  # See file size, etc.
+    - RUN_WINPWNAGE=dist/winpwnage.exe
 
 matrix:
   include:
@@ -53,7 +52,10 @@ matrix:
         - choco install vcredist2008
         - choco install --ignore-dependencies vcpython27
         - pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
-      <<: *py2exe-steps
+      before_script: &py2exe-steps
+        - python build_win64.py winpwnage.py
+        - ls -l dist  # See file size, etc.
+        - RUN_WINPWNAGE=dist/winpwnage.exe
     - name: "Py3: Build exe with py2exe"
       <<: *py37-steps
       install:
@@ -72,10 +74,12 @@ matrix:
 install:
   - pip install flake8
 
-script:
+before_script:
   - flake8 . --count --select=E9,F401,F63,F72,F82 --show-source --statistics
-  # <<: *scan-steps
-  - python winpwnage.py -scan -uac
-  - python winpwnage.py -scan -persist
-  - python winpwnage.py -scan -elevate
-  - python winpwnage.py -scan -execute
+  - RUN_WINPWNAGE="python winpwnage.py"
+
+script:
+  - $RUN_WINPWNAGE -scan -uac
+  - $RUN_WINPWNAGE -scan -persist
+  - $RUN_WINPWNAGE -scan -elevate
+  - $RUN_WINPWNAGE -scan -execute

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ env:
     - PY37PATH=/c/Python37:/c/Python37/Scripts
 
 py27-steps: &py27-steps
-  env: PATH=PY27PATH:$PATH
+  env: PATH=$PY27PATH:$PATH
   before_install:
     - choco install python2
     - python -m pip install --upgrade pip
     - python -m pip install -r requirements.txt
 
 py37-steps: &py37-steps
-  env: PATH=PY37PATH:$PATH
+  env: PATH=$PY37PATH:$PATH
   before_install:
     - choco install python
     - python -m pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ pyinstaller-steps: &pyinstaller-steps
   install:
     - pip install pyinstaller
   script:
-    - pyinstaller --onefile winpwnage.py
+    - pyinstaller --console --onefile winpwnage.py
     - ls dist
     - dist/winpwnage.exe  -scan -uac
     - dist/winpwnage.exe  -scan -persist
@@ -67,8 +67,9 @@ matrix:
     - name: "Py3: Build exe with PyInstaller"
       <<: *py37-steps
       <<: *pyinstaller-steps
-      before_script: pip uninstall -y enum34
-
+  allow_failures:
+    - name: "Py3: Build exe with py2exe"
+ 
 install:
   - pip install flake8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ install:
 
 script:
   - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
-  - python build.py winpwnage.py
+  - python build_win64.py winpwnage.py
   - ls
   - ls dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,20 @@ os: windows
 language: shell  # 'language: python' is not yet supported on Windows
 
 env:
-  global: PYTHONUNBUFFERED=1
+  global:
+    - PYTHONUNBUFFERED=1
+    - PY27PATH=/c/Python27:/c/Python27/Scripts
+    - PY37PATH=/c/Python37:/c/Python37/Scripts
 
 py27-steps: &py27-steps
-  env: PATH=/c/Python27:/c/Python27/Scripts:$PATH
+  env: PATH=$PY27PATH:$PATH
   before_install:
     - choco install python2
     - python -m pip install --upgrade pip
     - pip install -r requirements.txt
 
 py37-steps: &py37-steps
-  env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+  env: PATH=$PY37PATH:$PATH
   before_install:
     - choco install python
     - python -m pip install --upgrade pip
@@ -77,4 +80,3 @@ script:
   - python winpwnage.py -scan -persist
   - python winpwnage.py -scan -elevate
   - python winpwnage.py -scan -execute
-

--- a/build_win64.py
+++ b/build_win64.py
@@ -1,5 +1,4 @@
 from distutils.core import setup
-import py2exe
 import sys
 
 try:

--- a/build_win64.py
+++ b/build_win64.py
@@ -1,0 +1,23 @@
+from distutils.core import setup
+import py2exe
+import sys
+
+try:
+	args = sys.argv[1]
+except Exception as error:
+	sys.exit()
+
+sys.argv.pop()
+sys.argv.append("py2exe")
+sys.argv.append("-q")
+
+opts = {
+	"py2exe": {
+		"compressed": 2,
+		"optimize": 2,
+		# "bundle_files": 1,  # Win32
+		"bundle_files": 3,    # Win64
+	}
+}
+
+setup(console=[args], options=opts, zipfile=None)

--- a/build_win64.py
+++ b/build_win64.py
@@ -1,6 +1,8 @@
 from distutils.core import setup
 import sys
 
+import py2exe  # noqa: F401
+
 try:
 	args = sys.argv[1]
 except Exception as error:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 colorama
-enum34
+enum34 ; python_version<"3.4"'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 colorama
-enum34 ; python_version<"3.4"'
+enum34; python_version < '3.4'

--- a/winpwnage.py
+++ b/winpwnage.py
@@ -5,8 +5,8 @@ from winpwnage.core.scanner import scanner, function
 from winpwnage.core.utils import information
 
 print("""
-        _                               
-  _ _ _|_|___ ___ _ _ _ ___ ___ ___ ___ 
+        _
+  _ _ _|_|___ ___ _ _ _ ___ ___ ___ ___
  | | | | |   | . | | | |   | .'| . | -_|
  |_____|_|_|_|  _|_____|_|_|__,|_  |___|
              |_|               |___|
@@ -18,50 +18,50 @@ print_info("Build number: {}".format(information().build_number()))
 print_info("Running elevated: {}\n".format(information().admin()))
 
 def main():
-	#
-	# Scanner
-	#
-	if sys.argv[1].lower() == "-scan":
-		if sys.argv[2].lower() == "-uac":
-			scanner(uac=True, persist=False, elevate=False, execute=False).start()
-		elif sys.argv[2].lower() == "-persist":
-			scanner(uac=False, persist=True, elevate=False, execute=False).start()
-		elif sys.argv[2].lower() == "-elevate":
-			scanner(uac=False, persist=False, elevate=True, execute=False).start()
-		elif sys.argv[2].lower() == "-execute":
-			scanner(uac=False, persist=False, elevate=False, execute=True).start()
+    #
+    # Scanner
+    #
+    if sys.argv[1].lower() == "-scan":
+        if sys.argv[2].lower() == "-uac":
+            scanner(uac=True, persist=False, elevate=False, execute=False).start()
+        elif sys.argv[2].lower() == "-persist":
+            scanner(uac=False, persist=True, elevate=False, execute=False).start()
+        elif sys.argv[2].lower() == "-elevate":
+            scanner(uac=False, persist=False, elevate=True, execute=False).start()
+        elif sys.argv[2].lower() == "-execute":
+            scanner(uac=False, persist=False, elevate=False, execute=True).start()
 
-	#
-	# UAC bypass
-	#
-	elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-uac":
-		function(uac=True, persist=False, elevate=False,
-				execute=False).run(id=sys.argv[3], payload=sys.argv[4])		
+    #
+    # UAC bypass
+    #
+    elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-uac":
+        function(uac=True, persist=False, elevate=False,
+                 execute=False).run(id=sys.argv[3], payload=sys.argv[4])
 
-	#
-	# Persistence
-	#
-	elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-persist" and sys.argv[3].lower() == "-add":
-		function(uac=False, persist=True, elevate=False,
-				execute=False).run(id=sys.argv[4], payload=sys.argv[5], add=True)
+    #
+    # Persistence
+    #
+    elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-persist" and sys.argv[3].lower() == "-add":
+        function(uac=False, persist=True, elevate=False,
+                 execute=False).run(id=sys.argv[4], payload=sys.argv[5], add=True)
 
-	elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-persist" and sys.argv[3].lower() == "-remove":
-		function(uac=False, persist=True, elevate=False,
-				execute=False).run(id=sys.argv[4], payload=sys.argv[5], add=False)
+    elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-persist" and sys.argv[3].lower() == "-remove":
+        function(uac=False, persist=True, elevate=False,
+                 execute=False).run(id=sys.argv[4], payload=sys.argv[5], add=False)
 
-	#
-	# Elevate
-	#
-	elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-elevate":
-		function(uac=False, persist=False, elevate=True,
-				execute=False).run(id=sys.argv[3], payload=sys.argv[4])		
+    #
+    # Elevate
+    #
+    elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-elevate":
+        function(uac=False, persist=False, elevate=True,
+                 execute=False).run(id=sys.argv[3], payload=sys.argv[4])
 
-	#
-	# Execute
-	#
-	elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-execute":
-		function(uac=False, persist=False, elevate=False,
-				execute=True).run(id=sys.argv[3], payload=sys.argv[4])
+    #
+    # Execute
+    #
+    elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-execute":
+        function(uac=False, persist=False, elevate=False,
+                 execute=True).run(id=sys.argv[3], payload=sys.argv[4])
 
 if __name__ == "__main__":
-	main()
+    main()


### PR DESCRIPTION
Ready for review.  See #25

This PR delivers 6 Travis CI jobs that run in parallel:
1. Py2: Run tests
2. Py3: Run tests
3. Py2: Build exe with py2exe
4. Py3: Build exe with py2exe - _Run in allow_failures mode_
5. Py2: Build exe with PyInstaller
6. Py3: Build exe with PyInstaller

* The PyInstaller .exe files run on Travis but their console output is not visible
* Add a __build_win64.py__ file for py2exe on Win64
* Block install __enum34__ on Python >= 3.4 because it is already in the Python Standard Library
* Run __reindent.py winpwnage.py__ where ___reindent.py___ is a file that is shipped in every CPython distribution.
    * https://github.com/python/cpython/blob/master/Tools/scripts/reindent.py

Without reindent change, __PyInstaller__ builds succeed but the resulting .exe files generate nothing on stdout.  This is probably caused by a bare exception somewhere in the codebase swallowing indentation errors .




