### PR TITLE
URGENT: Fix build.py so it works again

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,6 +1,8 @@
 from distutils.core import setup
 import sys
 
+import py2exe  # noqa: F401
+
 try:
 	args = sys.argv[1]
 except Exception as error:


### PR DESCRIPTION
Ready for review.  The py2exe build fails without this change.

This import is __unused__ in a Python syntax sense but it does do some essential behind-the-scenes magic.