### PR TITLE
Removing py2exe build on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ matrix:
     - name: "Py3: Build exe with py2exe"
       <<: *py35-steps
       install:
-        - pip install py2exe
+        - pip install py2exe pyreadline
       before_script:
         - python -m py2exe.build_exe --bundle-files 0 winpwnage.py
         - ls -l dist  # See file size, etc.

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,6 @@ py37-steps: &py37-steps
     - python -m pip install --upgrade pip
     - pip install -r requirements.txt
 
-py2exe-steps: &py2exe-steps
-  before_script:
-    - python build_win64.py winpwnage.py
-    - ls -l dist  # See file size, etc.
-    - RUN_WINPWNAGE=dist/winpwnage.exe
-
 pyinstaller-steps: &pyinstaller-steps
   install:
     - pip install pyinstaller
@@ -63,12 +57,18 @@ matrix:
         - choco install vcredist2008
         - choco install --ignore-dependencies vcpython27
         - pip install https://nchc.dl.sourceforge.net/project/py2exe/py2exe/0.6.9/py2exe-0.6.9.zip
-      <<: *py2exe-steps
+      before_script:
+        - python build_win64.py winpwnage.py
+        - ls -l dist  # See file size, etc.
+        - RUN_WINPWNAGE=dist/winpwnage.exe
     - name: "Py3: Build exe with py2exe"
       <<: *py37-steps
       install:
         - pip install py2exe
-      <<: *py2exe-steps
+      before_script:
+        - python -m py2exe.build_exe --bundle-files 0 winpwnage.py
+        - ls -l dist  # See file size, etc.
+        - RUN_WINPWNAGE=dist/winpwnage.exe
 
     - name: "Py2: Build exe with PyInstaller"
       <<: *py27-steps

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ language: shell  # 'language: python' is not yet supported on Travis CI Windows
 env:
   global:
     - PY27PATH=/c/Python27:/c/Python27/Scripts
+    - PY35PATH=/c/Python35:/c/Python35/Scripts
     - PY37PATH=/c/Python37:/c/Python37/Scripts
 
 py27-steps: &py27-steps
@@ -27,6 +28,13 @@ py37-steps: &py37-steps
   env: PATH=$PY37PATH:$PATH
   before_install:
     - choco install python
+    - python -m pip install --upgrade pip
+    - pip install -r requirements.txt
+
+py35-steps: &py35-steps
+  env: PATH=$PY35PATH:$PATH
+  before_install:
+    - choco install python --version 3.5.4
     - python -m pip install --upgrade pip
     - pip install -r requirements.txt
 
@@ -62,7 +70,7 @@ matrix:
         - ls -l dist  # See file size, etc.
         - RUN_WINPWNAGE=dist/winpwnage.exe
     - name: "Py3: Build exe with py2exe"
-      <<: *py37-steps
+      <<: *py35-steps
       install:
         - pip install py2exe
       before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ language: shell  # 'language: python' is not yet supported on Travis CI Windows
 env:
   global:
     - PY27PATH=/c/Python27:/c/Python27/Scripts
-    - PY35PATH=/c/Python35:/c/Python35/Scripts
     - PY37PATH=/c/Python37:/c/Python37/Scripts
 
 py27-steps: &py27-steps
@@ -28,13 +27,6 @@ py37-steps: &py37-steps
   env: PATH=$PY37PATH:$PATH
   before_install:
     - choco install python
-    - python -m pip install --upgrade pip
-    - pip install -r requirements.txt
-
-py35-steps: &py35-steps
-  env: PATH=$PY35PATH:$PATH
-  before_install:
-    - choco install python --version 3.5.4
     - python -m pip install --upgrade pip
     - pip install -r requirements.txt
 
@@ -59,6 +51,13 @@ matrix:
     - name: "Py3: Run tests"
       <<: *py37-steps
 
+    - name: "Py2: Build exe with PyInstaller"
+      <<: *py27-steps
+      <<: *pyinstaller-steps
+    - name: "Py3: Build exe with PyInstaller"
+      <<: *py37-steps
+      <<: *pyinstaller-steps
+ 
     - name: "Py2: Build exe with py2exe"
       <<: *py27-steps
       install:
@@ -69,24 +68,7 @@ matrix:
         - python build_win64.py winpwnage.py
         - ls -l dist  # See file size, etc.
         - RUN_WINPWNAGE=dist/winpwnage.exe
-    - name: "Py3: Build exe with py2exe"
-      <<: *py35-steps
-      install:
-        - pip install py2exe pyreadline
-      before_script:
-        - python -m py2exe.build_exe --bundle-files 0 winpwnage.py
-        - ls -l dist  # See file size, etc.
-        - RUN_WINPWNAGE=dist/winpwnage.exe
 
-    - name: "Py2: Build exe with PyInstaller"
-      <<: *py27-steps
-      <<: *pyinstaller-steps
-    - name: "Py3: Build exe with PyInstaller"
-      <<: *py37-steps
-      <<: *pyinstaller-steps
-  allow_failures:
-    - name: "Py3: Build exe with py2exe"
- 
 install:
   - pip install flake8
 


### PR DESCRIPTION
Python 3.4 is already end of life and py2exe does not build on Python 3.5 or higher.

https://stackoverflow.com/questions/41578808/python-indexerror-tuple-index-out-of-range-when-using-py2exe

