### PR TITLE
scanner() and function() only take a single str parameter

### DIFF
--- a/winpwnage.py
+++ b/winpwnage.py
@@ -19,12 +19,13 @@ print_info("Running elevated: {}\n".format(information().admin()))
 
 
 def main():
-    #
-    # Scanner
-    #
-    verb = sys.argv[1].lstrip("-").lower()
+    try:
+        verb = sys.argv[1].lstrip("-").lower()
+        function_group = sys.argv[2].lstrip("-").lower()
+    except IndexError:
+        print("winpwnage [-scan, -use] [-uac, -persist, -elevate, -execute] ...")
+        return
     assert verb in ("scan", "use"), verb
-    function_group = sys.argv[2].lstrip("-").lower()
     assert function_group in ("uac", "persist", "elevate", "execute"), function_group
 
     if verb == "scan":

--- a/winpwnage.py
+++ b/winpwnage.py
@@ -19,11 +19,12 @@ print_info("Running elevated: {}\n".format(information().admin()))
 
     
 def main():
-    try:  # Each of the next 4 lines can raise IndexError
+    try:  # These 2 lines can raise an IndexError
         verb = sys.argv[1].lstrip("-").lower()
-        verb in ("scan", "use")
         function_group = sys.argv[2].lstrip("-").lower()
-        function_group in function_groups
+        # These 2 lines can raise an ValueError
+        ("scan", "use").index(verb)
+        list(function_groups).index(function_group)
 
         if verb == "scan":
             scanner(function_group).start()

--- a/winpwnage.py
+++ b/winpwnage.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import sys
 from winpwnage.core.prints import print_info
-from winpwnage.core.scanner import scanner, function
+from winpwnage.core.scanner import function, function_groups, scanner
 from winpwnage.core.utils import information
 
 print("""
@@ -17,27 +17,27 @@ print_info("UAC level: {}".format(information().uac_level()))
 print_info("Build number: {}".format(information().build_number()))
 print_info("Running elevated: {}\n".format(information().admin()))
 
-
+    
 def main():
-    try:
+    try:  # Each of the next 4 lines can raise IndexError
         verb = sys.argv[1].lstrip("-").lower()
+        verb in ("scan", "use")
         function_group = sys.argv[2].lstrip("-").lower()
-    except IndexError:
+        function_group in function_groups
+
+        if verb == "scan":
+            scanner(function_group).start()
+        # verb == "use"
+        elif function_group == "persist":  # use Persistence
+            # False if "-remove", True if "-add", raise ValueError on all other values
+            add = bool(("-remove", "-add").index(sys.argv[3].lower()))
+            function(function_group).run(id=sys.argv[4], payload=sys.argv[5], add=add)
+        else:  # use User Account Control or Elevate or Execute
+            function(function_group).run(id=sys.argv[3], payload=sys.argv[4])
+    except (IndexError, ValueError) as e:
+        print(str(e))
         print("winpwnage [-scan, -use] [-uac, -persist, -elevate, -execute] ...")
-        return
-    assert verb in ("scan", "use"), verb
-    assert function_group in ("uac", "persist", "elevate", "execute"), function_group
-
-    if verb == "scan":
-        scanner(function_group).start()
-
-    elif function_group == "persist":  # use Persistence
-        # False if "-remove", True if "-add", raise ValueError on all other values
-        add = bool(("-remove", "-add").index(sys.argv[3].lower()))
-        function(function_group).run(id=sys.argv[4], payload=sys.argv[5], add=add)
-
-    else:  # use User Account Control or Elevate or Execute
-        function(function_group).run(id=sys.argv[3], payload=sys.argv[4])
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/winpwnage.py
+++ b/winpwnage.py
@@ -17,51 +17,27 @@ print_info("UAC level: {}".format(information().uac_level()))
 print_info("Build number: {}".format(information().build_number()))
 print_info("Running elevated: {}\n".format(information().admin()))
 
+
 def main():
     #
     # Scanner
     #
-    if sys.argv[1].lower() == "-scan":
-        if sys.argv[2].lower() == "-uac":
-            scanner(uac=True, persist=False, elevate=False, execute=False).start()
-        elif sys.argv[2].lower() == "-persist":
-            scanner(uac=False, persist=True, elevate=False, execute=False).start()
-        elif sys.argv[2].lower() == "-elevate":
-            scanner(uac=False, persist=False, elevate=True, execute=False).start()
-        elif sys.argv[2].lower() == "-execute":
-            scanner(uac=False, persist=False, elevate=False, execute=True).start()
+    verb = sys.argv[1].lstrip("-").lower()
+    assert verb in ("scan", "use"), verb
+    function_group = sys.argv[2].lstrip("-").lower()
+    assert function_group in ("uac", "persist", "elevate", "execute"), function_group
 
-    #
-    # UAC bypass
-    #
-    elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-uac":
-        function(uac=True, persist=False, elevate=False,
-                 execute=False).run(id=sys.argv[3], payload=sys.argv[4])
+    if verb == "scan":
+        scanner(function_group).start()
 
-    #
-    # Persistence
-    #
-    elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-persist" and sys.argv[3].lower() == "-add":
-        function(uac=False, persist=True, elevate=False,
-                 execute=False).run(id=sys.argv[4], payload=sys.argv[5], add=True)
+    elif function_group == "persist":  # use Persistence
+        # False if "-remove", True if "-add", raise ValueError on all other values
+        add = bool(("-remove", "-add").index(sys.argv[3].lower()))
+        function(function_group).run(id=sys.argv[4], payload=sys.argv[5], add=add)
 
-    elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-persist" and sys.argv[3].lower() == "-remove":
-        function(uac=False, persist=True, elevate=False,
-                 execute=False).run(id=sys.argv[4], payload=sys.argv[5], add=False)
+    else:  # use User Account Control or Elevate or Execute
+        function(function_group).run(id=sys.argv[3], payload=sys.argv[4])
 
-    #
-    # Elevate
-    #
-    elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-elevate":
-        function(uac=False, persist=False, elevate=True,
-                 execute=False).run(id=sys.argv[3], payload=sys.argv[4])
-
-    #
-    # Execute
-    #
-    elif sys.argv[1].lower() == "-use" and sys.argv[2].lower() == "-execute":
-        function(uac=False, persist=False, elevate=False,
-                 execute=True).run(id=sys.argv[3], payload=sys.argv[4])
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
In __scanner.py__:
Line 61: Rename functions to function_groups
line 125 and 142: Do not pass in a bool for each function_group but instead tell us the one function_group you want
line 134 and 149: Do a dict lookup (__function_groups[self.function_group]__) to get info for the functions in that function_group

The dict lookup allows us to remove a bunch of code and dedent the code below it.

Once __scanner()__ and __function()__ only take a single str parameter we can simplify __main()__ as well.
